### PR TITLE
Fix incorrect result limit

### DIFF
--- a/openerz_api/main.py
+++ b/openerz_api/main.py
@@ -47,7 +47,7 @@ class OpenERZConnector:
             "start": start_date,
             "end": end_date,
             "offset": 0,
-            "limit": 0,
+            "limit": 1,
             "lang": "en",
             "sort": "date",
         }


### PR DESCRIPTION
Since beginning of January the Home-Assistant integration "Open ERZ" does not work anymore.
After tracking down the error a bit, it became clear that the call to the api contains an asumption which is not valid any more.

The original error in Home-Assistant was:
```
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/helpers/entity_platform.py", line 503, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/helpers/entity.py", line 729, in async_device_update
    await task
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.10/site-packages/homeassistant/components/openerz/sensor.py", line 66, in update
    self._state = self.api_connector.find_next_pickup(day_offset=31)
  File "/srv/homeassistant/lib/python3.10/site-packages/openerz_api/main.py", line 91, in find_next_pickup
    next_pickup_date = self.parse_api_response()
  File "/srv/homeassistant/lib/python3.10/site-packages/openerz_api/main.py", line 75, in parse_api_response
    first_scheduled_pickup = result_list[0]
IndexError: list index out of range
```

The api returned:

```
{'_metadata': {'total_count': 1, 'row_count': 0}, 'result': []}
```

It seems that the handling of "limit" changed in the edgecase of "limit=0".

The fix is to increase the "limit".

With "limit=1" the api returns:

```
{'_metadata': {'total_count': 1, 'row_count': 1}, 'result': [{'date': '2023-01-11', 'type': 'paper', 'zip': 8001, 'area': '8001', 'station': '', 'region': 'zurich'}]}
```

To get the Home-Assistant integration working again, a fixed version of this package at pypi.org is necessary.