### PR TITLE
[Fix] adapted query to metaodi/openerz#146

### DIFF
--- a/openerz_api/main.py
+++ b/openerz_api/main.py
@@ -44,6 +44,7 @@ class OpenERZConnector:
 
         payload = {
             "zip": self.zip,
+            "types":self.waste_type,
             "start": start_date,
             "end": end_date,
             "offset": 0,
@@ -51,7 +52,7 @@ class OpenERZConnector:
             "lang": "en",
             "sort": "date",
         }
-        url = f"http://openerz.metaodi.ch/api/calendar/{self.waste_type}.json"
+        url = f"https://openerz.metaodi.ch/api/calendar.json"
 
         try:
             self.last_api_response = requests.get(url, params=payload, headers=headers)
@@ -73,7 +74,7 @@ class OpenERZConnector:
             return None
         result_list = response_json.get("result")
         first_scheduled_pickup = result_list[0]
-        if first_scheduled_pickup["zip"] == self.zip and first_scheduled_pickup["type"] == self.waste_type:
+        if first_scheduled_pickup["zip"] == self.zip and first_scheduled_pickup["waste_type"] == self.waste_type:
             return first_scheduled_pickup["date"]
         self.logger.warning("Either zip or waste type does not match the ones specified in the configuration.")
         return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,9 +87,10 @@ def test_sensor_make_api_request():
             test_openerz.make_api_request()
 
             expected_headers = {"accept": "application/json"}
-            expected_url = "http://openerz.metaodi.ch/api/calendar/glass.json"
+            expected_url = "https://openerz.metaodi.ch/api/calendar.json"
             expected_payload = {
                 "zip": 1234,
+                "types": "glass",
                 "start": "2019-12-10",
                 "end": "2020-01-10",
                 "offset": 0,
@@ -134,7 +135,7 @@ def test_sensor_parse_api_response_ok():
 
         response_data = {
             "_metadata": {"total_count": 1},
-            "result": [{"zip": 1234, "type": "glass", "date": "2020-01-10"}],
+            "result": [{"zip": 1234, "waste_type": "glass", "date": "2020-01-10"}],
         }
         test_openerz.last_api_response = MockAPIResponse(True, 200, response_data)
 
@@ -197,7 +198,7 @@ def test_sensor_parse_api_response_wrong_type():
 
         response_data = {
             "_metadata": {"total_count": 1},
-            "result": [{"zip": 1234, "type": "metal", "date": "2020-01-10"}],
+            "result": [{"zip": 1234, "waste_type": "metal", "date": "2020-01-10"}],
         }
 
         with LogCapture() as captured_logs:


### PR DESCRIPTION
Since January 8 with release of [metaodi/openerz  v8.0.0](https://github.com/metaodi/openerz/releases/tag/v8.0.0) Home Assistant does not show any waste collection times and gives an error.
In this pull request I adapted the required request to the new version of openerz.  

To get the Home-Assistant integration working again, a fixed version of this package at pypi.org is necessary.

The mentioned error in Home Assistant:
```
openerz: Error on device update!

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 971, in json
    return complexjson.loads(self.text, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/simplejson/__init__.py", line 514, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/simplejson/decoder.py", line 386, in decode
    obj, end = self.raw_decode(s)
               ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/simplejson/decoder.py", line 416, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 573, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1214, in async_device_update
    await hass.async_add_executor_job(self.update)
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/openerz/sensor.py", line 66, in update
    self._state = self.api_connector.find_next_pickup(day_offset=31)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openerz_api/main.py", line 91, in find_next_pickup
    next_pickup_date = self.parse_api_response()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openerz_api/main.py", line 70, in parse_api_response
    response_json = self.last_api_response.json()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```


